### PR TITLE
AscentMS/Dev#1704 - removed URL encoding

### DIFF
--- a/src/android/com/synconset/CordovaHTTP/CordovaHttpDownload.java
+++ b/src/android/com/synconset/CordovaHTTP/CordovaHttpDownload.java
@@ -33,7 +33,7 @@ public class CordovaHttpDownload extends CordovaHttp implements Runnable {
     @Override
     public void run() {
         try {
-            HttpRequest request = HttpRequest.get(this.getUrlString(), this.getParams(), true);
+            HttpRequest request = HttpRequest.get(this.getUrlString(), this.getParams(), false);
             this.setupSecurity(request);
             request.acceptCharset(CHARSET);
             request.headers(this.getHeaders());

--- a/src/android/com/synconset/CordovaHTTP/CordovaHttpGet.java
+++ b/src/android/com/synconset/CordovaHTTP/CordovaHttpGet.java
@@ -33,7 +33,7 @@ public class CordovaHttpGet extends CordovaHttp implements Runnable {
     @Override
     public void run() {
         try {
-            HttpRequest request = HttpRequest.get(this.getUrlString(), this.getParams(), true);
+            HttpRequest request = HttpRequest.get(this.getUrlString(), this.getParams(), false);
             this.setupSecurity(request);
             request.acceptCharset(CHARSET);
             request.headers(this.getHeaders());


### PR DESCRIPTION
Removed URL encoding for Java HTTP requests
(was inconsistent with the Objective-C or Fetch API methods)

See https://github.com/wymsee/cordova-HTTP/commit/46517ae7f2816fec063e38d180b8a2258d40d896 for reference.